### PR TITLE
chore: change wagmi wallet to metamask connector

### DIFF
--- a/src/components/wallet/index.js
+++ b/src/components/wallet/index.js
@@ -3,11 +3,12 @@ import { useSelector, useDispatch, shallowEqual } from "react-redux";
 import { providers, utils } from "ethers";
 import _ from "lodash";
 import { useConnect } from "wagmi";
-import { InjectedConnector } from "wagmi/connectors/injected";
+import { MetaMaskConnector } from "wagmi/connectors/metaMask";
 import Web3Modal from "web3modal";
 
 import { getChain } from "~/lib/chain/utils";
 import { WALLET_DATA, WALLET_RESET } from "~/reducers/types";
+import { getWagmiChains } from "~/lib/providers/WagmiConfigProvider";
 
 const providerOptions = {};
 
@@ -124,7 +125,13 @@ const Wallet = ({
     const { chainId } = { ...network };
 
     wagmiConnect({
-      connector: new InjectedConnector(),
+      connector: new MetaMaskConnector({
+        chains: getWagmiChains(),
+        options: {
+          shimDisconnect: false,
+          shimChainChangedDisconnect: false,
+        },
+      }),
     });
 
     dispatch({

--- a/src/lib/providers/WagmiConfigProvider.tsx
+++ b/src/lib/providers/WagmiConfigProvider.tsx
@@ -20,7 +20,7 @@ import {
   optimismGoerli,
   moonbaseAlpha,
 } from "wagmi/chains";
-import { InjectedConnector } from "wagmi/connectors/injected";
+import { MetaMaskConnector } from "wagmi/connectors/metaMask";
 import { publicProvider } from "wagmi/providers/public";
 
 const chainConfigs = [
@@ -112,7 +112,15 @@ const client = createClient({
   autoConnect: true,
   provider,
   webSocketProvider,
-  connectors: [new InjectedConnector()],
+  connectors: [
+    new MetaMaskConnector({
+      chains: chainConfigs,
+      options: {
+        shimDisconnect: false,
+        shimChainChangedDisconnect: false,
+      },
+    }),
+  ],
 });
 
 const WagmiConfigProvider: FC<PropsWithChildren> = ({ children }) => {


### PR DESCRIPTION
using the metamask connector will allow for seamless switching of chains on metamask (instead of the generic injectedconnector). if you're testing, will need to clear cookies/localstorage first