### PR TITLE
chore: hide the GMP Express page

### DIFF
--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -60,6 +60,12 @@ const Dashboard = () => {
     );
   }, [inputSearch]);
 
+  useEffect(() => {
+    if (services.length === 1) {
+      router.push(_.head(services)?.path);
+    }
+  }, [services]);
+
   return (
     <div className="mt-0 grid grid-cols-1 gap-4 sm:mt-4 sm:grid-cols-2 lg:grid-cols-3 lg:gap-8">
       {filteredServices.map((s, i) => {

--- a/src/components/navbar/navigations/menus.js
+++ b/src/components/navbar/navigations/menus.js
@@ -4,6 +4,7 @@ import services from "~/config/services";
 
 export default _.concat(
   [
+    services.length > 1 &&
     {
       id: "dashboard",
       title: "Dashboard",

--- a/src/config/services.js
+++ b/src/config/services.js
@@ -19,5 +19,6 @@ export default [
     tags: ["GMP", "GMP Express", "Cross Chain"],
     navbar_visible: true,
     coming_soon: true,
+    disabled: true,
   },
-].filter((s) => s?.path);
+].filter((s) => s?.path && !s.disabled);


### PR DESCRIPTION
chore: disable (hide) the GMP Express page and redirect to the interchain token as a frontpage.